### PR TITLE
salt: Replace dependency on lsb with lsb-release

### DIFF
--- a/meta-openstack/recipes-support/salt/salt_3000.bb
+++ b/meta-openstack/recipes-support/salt/salt_3000.bb
@@ -100,7 +100,7 @@ SUMMARY_${PN}-common = "shared libraries that salt requires for all packages"
 DESCRIPTION_${PN}-common ="${DESCRIPTION_COMMON} This particular package provides shared libraries that \
 salt-master, salt-minion, and salt-syndic require to function."
 RDEPENDS_${PN}-common = "python3-dateutil python3-jinja2 python3-pyyaml python3-requests (>= 1.0.0)"
-RRECOMMENDS_${PN}-common = "lsb"
+RRECOMMENDS_${PN}-common = "lsb-release"
 RSUGGESTS_${PN}-common = "python3-mako python3-git"
 RCONFLICTS_${PN}-common = "python3-mako (< 0.7.0)"
 CONFFILES_${PN}-common="${sysconfdir}/logrotate.d/${PN}"


### PR DESCRIPTION
lsb is deprecated upstream and is no longer shipped.
So remove as it is only a recommended dependency.

Signed-off-by: Chaitanya Vadrevu <chaitanya.vadrevu@ni.com>