### PR TITLE
Fix build errors/warnings in salt_3001

### DIFF
--- a/meta-openstack/recipes-support/salt/salt_3001.1.bb
+++ b/meta-openstack/recipes-support/salt/salt_3001.1.bb
@@ -1,7 +1,7 @@
 HOMEPAGE = "http://saltstack.com/"
 SECTION = "admin"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ac9a49d86925151327b277d6a3999a07"
 DEPENDS = "\
            python3-msgpack \
            python3-pyyaml \

--- a/meta-openstack/recipes-support/salt/salt_3001.1.bb
+++ b/meta-openstack/recipes-support/salt/salt_3001.1.bb
@@ -18,7 +18,7 @@ PACKAGECONFIG ??= "zeromq"
 PACKAGECONFIG[zeromq] = ",,python3-pyzmq python3-pycrypto,"
 PACKAGECONFIG[tcp] = ",,python3-pycrypto"
 
-SRC_URI = "https://files.pythonhosted.org/packages/source/s/${PN}/${PN}-${PV}.tar.gz \
+SRC_URI = "https://files.pythonhosted.org/packages/source/s/${BPN}/${BPN}-${PV}.tar.gz \
 "
 
 SRC_URI[md5sum] = "4174a6dd2c7eee808086ca06bdd928c9"


### PR DESCRIPTION
Until we can put in the work to properly upgrade NILRT's salt implementation for hardknott, we should just accept the salt_3001 recipe from meta-cloud-services upstream as-is.

This patchset:
1. corrects the md5sum of the salt_3001 recipe to make it a value that is actually used.
  * AFAICT, the md5sum that is in meta-cloud-services upstream has never been used in the salt source, so I'm not sure where they got it from, or how upstream's builds worked.
  * We made a similar change in the dunfell branch of meta-nilrt [previously](https://github.com/ni/meta-nilrt/commit/3665ad58a753a8a31e4879bbbe014db064c27465#diff-bf63bae4eb5e247e118cb6ceb9d405dae8e078649a7358e546f03157ecba555d); but we never upstreamed it.
2. satisfies a bitbake warning about `SRC_URI` using `PN` instead of `BPN`.

Both of these commits will be rebased and submitted to meta-cloud-services upstream, once this PR is accepted internally.

## Testing
The `salt` recipe builds without issue now.

@ni/rtos 