### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/meta-openstack/recipes-devtools/python/python-appdirs_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-appdirs_git.bb
@@ -8,7 +8,7 @@ PV = "1.4.0"
 SRCREV = "57f2bc44a8bca99bac6c57496c8b3fdea26f94d5"
 
 SRCNAME = "appdirs"
-SRC_URI = "git://github.com/ActiveState/${SRCNAME}.git"
+SRC_URI = "git://github.com/ActiveState/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-barbican_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-barbican_git.bb
@@ -8,7 +8,7 @@ PR = "r0"
 SRCNAME = "barbican"
 BARBICAN_MAX_PACKET_SIZE ?= "65535"
 
-SRC_URI = "git://github.com/openstack/barbican.git;branch=master \
+SRC_URI = "git://github.com/openstack/barbican.git;branch=master;protocol=https \
            file://barbican.init \
            file://barbican-increase-buffer-size-to-support-PKI-tokens.patch \
            file://barbican-fix-path-to-find-configuration-files.patch \

--- a/meta-openstack/recipes-devtools/python/python-barbicanclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-barbicanclient_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e031cff4528978748f9cc064c6e6fa73"
 
 SRC_URI = "\
-	git://github.com/openstack/python-barbicanclient.git;branch=stable/pike \
+	git://github.com/openstack/python-barbicanclient.git;branch=stable/pike;protocol=https \
 	"
 
 PV = "4.5.2+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-boto_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-boto_git.bb
@@ -9,7 +9,7 @@ PV = "2.8.0+git${SRCPV}"
 PR = "r0"
 SRCNAME = "boto"
 
-SRC_URI = "git://github.com/boto/boto.git;protocol=git"
+SRC_URI = "git://github.com/boto/boto.git;protocol=https"
 
 SRC_URI[md5sum] = "5528f3010c42dd0ed7b188a6917295f1"
 SRC_URI[sha256sum] = "4d6d38aa8e9e536a27a9737eb4222f896417841fed9a12eedcb619ba8fb68a39"

--- a/meta-openstack/recipes-devtools/python/python-cachetools_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-cachetools_git.bb
@@ -9,7 +9,7 @@ SRCNAME = "cachetools"
 PV = "1.1.5+git${SRCPV}"
 SRCREV = "42853733d0caf68ef5bf5933a377572b05437e2c"
 
-SRC_URI = "git://github.com/tkem/${SRCNAME}.git"
+SRC_URI = "git://github.com/tkem/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-ceilometer_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-ceilometer_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "ceilometer"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://ceilometer.conf \
            file://ceilometer.init \
            file://fix_ceilometer_memory_leak.patch \

--- a/meta-openstack/recipes-devtools/python/python-ceilometerclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-ceilometerclient_git.bb
@@ -28,7 +28,7 @@ RDEPENDS_${PN} += " \
         "
 
 SRC_URI = "\
-	git://github.com/openstack/python-ceilometerclient.git;branch=stable/pike \
+	git://github.com/openstack/python-ceilometerclient.git;branch=stable/pike;protocol=https \
 	"
 
 PV = "2.9.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-cinder_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-cinder_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "cinder"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
     file://cinder-init \
     file://cinder-init.service \
     file://cinder-api.service \

--- a/meta-openstack/recipes-devtools/python/python-cinderclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-cinderclient_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "python-setuptools-git"
 SRCNAME = "python-cinderclient"
 
 SRC_URI = "\
-	git://github.com/openstack/python-cinderclient.git;branch=stable/pike \
+	git://github.com/openstack/python-cinderclient.git;branch=stable/pike;protocol=https \
 	file://cinder-api-check.sh \
 	"
 

--- a/meta-openstack/recipes-devtools/python/python-designateclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-designateclient_git.bb
@@ -28,7 +28,7 @@ RDEPENDS_${PN} += " \
         "
 
 SRCNAME = "designateclient"
-SRC_URI = "git://github.com/openstack/${BPN}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${BPN}.git;branch=stable/pike;protocol=https"
 
 PV = "2.7.0+git${SRCPV}"
 SRCREV = "77a705857f2c303a03fdbccd4460a68b61d92fd0"

--- a/meta-openstack/recipes-devtools/python/python-django-babel_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-django-babel_git.bb
@@ -9,7 +9,7 @@ SRCNAME = "django-babel"
 PV = "0.5.1+git${SRCPV}"
 SRCREV = "88b389381c0e269605311ae07029555b65a86bc5"
 
-SRC_URI = "git://github.com/python-babel/${SRCNAME}.git \
+SRC_URI = "git://github.com/python-babel/${SRCNAME}.git;protocol=https \
           "
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-django-openstack-auth_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-django-openstack-auth_git.bb
@@ -9,7 +9,7 @@ SRCNAME = "django_openstack_auth"
 PV = "3.5.0+git${SRCPV}"
 SRCREV = "9e108ed426a5a1e5c9dd394b197c27d046754d0c"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
 "
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-django_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-django_git.bb
@@ -10,7 +10,7 @@ PV = "1.8.6"
 SRCREV = "80b7e9d09f2d23209b591288f9b2cf3eb3d927c8"
 
 SRC_URI = " \
-    git://github.com/django/django.git;branch=stable/1.8.x \
+    git://github.com/django/django.git;branch=stable/1.8.x;protocol=https \
     "
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-fasteners_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-fasteners_git.bb
@@ -9,7 +9,7 @@ SRCNAME = "fasteners"
 PV = "0.13.0+git${SRCPV}"
 SRCREV = "c055890c98f67c343ff445973cd4efee67f081ce"
 
-SRC_URI = "git://github.com/harlowja/${SRCNAME}.git"
+SRC_URI = "git://github.com/harlowja/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-functools32_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-functools32_git.bb
@@ -9,7 +9,7 @@ SRCREV = "ad90fa86e2f4f494a3aedb0571274f3bbc6d7ab5"
 SRCNAME = "functools32"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=27cf2345969ed18e6730e90fb0063a10"
-SRC_URI = "git://github.com/MiCHiLU/python-${SRCNAME}.git"
+SRC_URI = "git://github.com/MiCHiLU/python-${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-futures_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-futures_git.bb
@@ -8,7 +8,7 @@ PV = "3.0.3+git${SRCPV}"
 SRCREV = "6532a7449d8102c172ea5011f1552fcc163c09f1"
 
 SRCNAME = "futures"
-SRC_URI = "git://github.com/agronholm/python${SRCNAME}.git"
+SRC_URI = "git://github.com/agronholm/python${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-glance_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-glance_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "glance"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://glance.init \
            file://glance-api.service \
            file://glance-registry.service \

--- a/meta-openstack/recipes-devtools/python/python-glanceclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-glanceclient_git.bb
@@ -13,7 +13,7 @@ SRCREV = "13b25ff1fed908cfe7b4e719a97efd7121e3be96"
 PV = "2.8.0+git${SRCPV}"
 
 SRC_URI = "\
-	git://github.com/openstack/${BPN}.git;branch=stable/pike \
+	git://github.com/openstack/${BPN}.git;branch=stable/pike;protocol=https \
 	file://glance-api-check.sh \
 	"
 

--- a/meta-openstack/recipes-devtools/python/python-glancestore_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-glancestore_git.bb
@@ -8,7 +8,7 @@ SRCREV = "c816b38d9f12be75d989409cbab6dfefa8f49dc3"
 PV = "0.9.1+git${SRCPV}"
 
 SRC_URI = "\
-	git://github.com/openstack/glance_store.git \
+	git://github.com/openstack/glance_store.git;protocol=https \
 	"
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-heat_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-heat_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "heat"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://heat.conf \
            file://heat.init \
            file://autoscaling_example.template \

--- a/meta-openstack/recipes-devtools/python/python-heatclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-heatclient_git.bb
@@ -26,7 +26,7 @@ RDEPENDS_${PN} +="python-cliff \
 PR = "r0"
 SRCNAME = "heatclient"
 
-SRC_URI = "git://github.com/openstack/python-heatclient.git;branch=master"
+SRC_URI = "git://github.com/openstack/python-heatclient.git;branch=master;protocol=https"
 
 PV = "1.14.0+git${SRCPV}"
 SRCREV = "2ce6aa19a3a8936bc7c9737efadacbb4ae737dab"

--- a/meta-openstack/recipes-devtools/python/python-horizon_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-horizon_git.bb
@@ -73,7 +73,7 @@ RDEPENDS_${PN} += " \
 
 SRCNAME = "horizon"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
     file://wsgi-horizon.conf \
     file://fix_bindir_path.patch \
     file://local_settings.py \

--- a/meta-openstack/recipes-devtools/python/python-jsonpath-rw-ext_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-jsonpath-rw-ext_git.bb
@@ -9,7 +9,7 @@ SRCREV = "0a2d032f9743f5c9dd0f29be20a22b3f3388a93d"
 SRCNAME = "jsonpath-rw-ext"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
-SRC_URI = "git://github.com/sileht/${BPN}.git"
+SRC_URI = "git://github.com/sileht/${BPN}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-kafka_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-kafka_git.bb
@@ -9,7 +9,7 @@ SRCREV = "4955582be1443b75c23f700268b7abbef0fde0ad"
 SRCNAME = "kafka-python"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=22efebb1e053dcc946f4b9d17f3cbbea"
-SRC_URI = "git://github.com/mumrah/${SRCNAME}.git"
+SRC_URI = "git://github.com/mumrah/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-keystone-hybrid-backend_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-keystone-hybrid-backend_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://hybrid_identity.py;beginline=1;endline=14;md5=06c14f6
 
 PR = "r0"
 
-SRC_URI = "git://github.com/SUSE-Cloud/keystone-hybrid-backend.git;branch=havana"
+SRC_URI = "git://github.com/SUSE-Cloud/keystone-hybrid-backend.git;branch=havana;protocol=https"
 
 PV="git${SRCPV}"
 SRCREV="0bd376242f8522edef7031d2339b9533b86c17aa"

--- a/meta-openstack/recipes-devtools/python/python-keystone_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-keystone_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "keystone"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://keystone-init \
            file://keystone-init.service \
            file://keystone.conf \

--- a/meta-openstack/recipes-devtools/python/python-keystoneclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-keystoneclient_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4a4d0e932ffae1c0131528d30d419c55"
 SRCNAME = "keystoneclient"
 
 SRC_URI = "\
-	git://github.com/openstack/python-keystoneclient.git;branch=stable/pike \
+	git://github.com/openstack/python-keystoneclient.git;branch=stable/pike;protocol=https \
 	file://keystone-api-check.sh \
 	"
 

--- a/meta-openstack/recipes-devtools/python/python-magnumclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-magnumclient_git.bb
@@ -30,7 +30,7 @@ RDEPENDS_${PN} +=" \
 	"
 
 SRCNAME = "magnumclient"
-SRC_URI = "git://github.com/openstack/${BPN}.git;branch=master"
+SRC_URI = "git://github.com/openstack/${BPN}.git;branch=master;protocol=https"
 
 PV = "1.0.0.0b1+git${SRCPV}"
 SRCREV = "fb1ff6777eb96a5b7ba38156bf8354cda9b88ad4"

--- a/meta-openstack/recipes-devtools/python/python-manilaclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-manilaclient_git.bb
@@ -31,7 +31,7 @@ RDEPENDS_${PN} +=" \
 	"
 
 SRCNAME = "manilaclient"
-SRC_URI = "git://github.com/openstack/${BPN}.git;branch=master"
+SRC_URI = "git://github.com/openstack/${BPN}.git;branch=master;protocol=https"
 
 PV = "1.4.0+git${SRCPV}"
 SRCREV = "0bbd2144f701df3408b1435b16611c2ba3c22221"

--- a/meta-openstack/recipes-devtools/python/python-memcached_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-memcached_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://PSF.LICENSE;md5=7dd786e8594f1e787da94a946557b40e"
 PV = "1.57+git${SRCPV}"
 SRCREV = "664bd3e23fe500fbde4c70636e2d24c8fd2f35af"
 
-SRC_URI = "git://github.com/linsomniac/${BPN}.git"
+SRC_URI = "git://github.com/linsomniac/${BPN}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-microversion-parse_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-microversion-parse_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
 SRC_URI = "\
-	git://github.com/openstack/microversion-parse.git;branch=master \
+	git://github.com/openstack/microversion-parse.git;branch=master;protocol=https \
 	"
 
 PV = "0.1.4+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-mistralclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-mistralclient_git.bb
@@ -23,7 +23,7 @@ RDEPENDS_${PN} +=" \
 	"
 
 SRCNAME = "mistralclient"
-SRC_URI = "git://github.com/openstack/${BPN}.git;branch=master"
+SRC_URI = "git://github.com/openstack/${BPN}.git;branch=master;protocol=https"
 
 PV = "1.1.0+git${SRCPV}"
 SRCREV = "48e2780ee0148efc186c8972ca22e572fa2433c5"

--- a/meta-openstack/recipes-devtools/python/python-monotonic_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-monotonic_git.bb
@@ -8,7 +8,7 @@ PV = "0.4"
 SRCREV = "93b3d3ba63597e57b20333db4e33ca0f48debf2a"
 
 SRCNAME = "monotonic"
-SRC_URI = "git://github.com/atdt/${SRCNAME}.git"
+SRC_URI = "git://github.com/atdt/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-neutron_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-neutron_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "neutron"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://neutron-server.service \
            file://neutron.conf \
            file://l3_agent.ini \

--- a/meta-openstack/recipes-devtools/python/python-neutronclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-neutronclient_git.bb
@@ -33,7 +33,7 @@ RDEPENDS_${PN} += " \
         python-babel \
         "
 
-SRC_URI = "git://github.com/openstack/python-neutronclient.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/python-neutronclient.git;branch=stable/pike;protocol=https \
            file://neutronclient-use-csv-flag-instead-of-json.patch \
            file://neutron-api-check.sh \
           "

--- a/meta-openstack/recipes-devtools/python/python-nova_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-nova_git.bb
@@ -13,7 +13,7 @@ SRCNAME = "nova"
 
 FILESEXTRAPATHS_append := "${THISDIR}/${PN}"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://neutron-api-set-default-binding-vnic_type.patch \
            "
 

--- a/meta-openstack/recipes-devtools/python/python-novaclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-novaclient_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7cdb54622cacc9bc9b2883091e6dd669"
 
 SRC_URI = "\
-	git://github.com/openstack/python-novaclient.git;branch=stable/pike \
+	git://github.com/openstack/python-novaclient.git;branch=stable/pike;protocol=https \
 	file://nova-api-check.sh \
 	"
 

--- a/meta-openstack/recipes-devtools/python/python-novnc_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-novnc_git.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=6458695fb66dcd893becb5f9f912715e"
 SRCREV = "3b8ec46fd26d644e6edbea4f46e630929297e448"
 PV = "0.5.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/kanaka/noVNC.git \
+SRC_URI = "git://github.com/kanaka/noVNC.git;protocol=https \
            file://python-distutils.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-openstackclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-openstackclient_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI = " \
-        git://github.com/openstack/python-openstackclient.git;branch=stable/pike \
+        git://github.com/openstack/python-openstackclient.git;branch=stable/pike;protocol=https \
         "
 
 PV = "3.12.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-openstacksdk_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-openstacksdk_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRC_URI = " \
-        git://github.com/openstack/python-openstacksdk.git;branch=master \
+        git://github.com/openstack/python-openstacksdk.git;branch=master;protocol=https \
         "
 
 PV = "0.9.19+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-os-brick_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-os-brick_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI = "\
-	git://github.com/openstack/os-brick.git;branch=stable/pike \
+	git://github.com/openstack/os-brick.git;branch=stable/pike;protocol=https \
 	"
 
 PV = "1.15.5+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-os-client-config_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-os-client-config_git.bb
@@ -8,7 +8,7 @@ PV = "1.28.0"
 SRCREV = "261c05f0057d556a8910457f1e22ca4d81801081"
 
 SRCNAME = "os-client-config"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-os-traits_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-os-traits_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI = "\
-	git://github.com/openstack/os-traits.git;branch=stable/pike \
+	git://github.com/openstack/os-traits.git;branch=stable/pike;protocol=https \
 	"
 
 PV = "0.3.3+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-os-vif_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-os-vif_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI = "\
-	git://github.com/openstack/os-vif.git;branch=stable/pike \
+	git://github.com/openstack/os-vif.git;branch=stable/pike;protocol=https \
 	"
 
 PV = "1.7.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-os-win_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-os-win_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRC_URI = "\
-	git://github.com/openstack/os-win.git;branch=stable/pike \
+	git://github.com/openstack/os-win.git;branch=stable/pike;protocol=https \
 	"
 
 PV = "2.2.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-os-xenapi_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-os-xenapi_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "os-xenapi"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https"
 
 PV = "0.3.1+git${SRCPV}"
 SRCREV = "7dce682e2ab0c14236dbc58a38c925536b3b6f8d"

--- a/meta-openstack/recipes-devtools/python/python-oslo.cache_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.cache_git.bb
@@ -8,7 +8,7 @@ PV = "1.14.0+git${SRCPV}"
 SRCREV = "f5b6ddf7d18a7e06e19712ca7a2509d658a08c4d"
 
 SRCNAME = "oslo.cache"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.concurrency_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.concurrency_git.bb
@@ -8,7 +8,7 @@ PV = "3.21.1+git${SRCPV}"
 SRCREV = "8adf9b1f0d69dca7372b967ef4f894487f1a9d64"
 
 SRCNAME = "oslo.concurrency"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.config_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.config_git.bb
@@ -8,7 +8,7 @@ PV = "4.11.1+git${SRCPV}"
 SRCREV = "fb0738974824af6e1bc7d9fdf32a7c1d3ebf65fb"
 
 SRCNAME = "oslo.config"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.context_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.context_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "oslo.context"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "2.17.0+git${SRCPV}"
 SRCREV = "f4b6914db02e6bcf0de4a97bbc3dc85dd6e06d91"

--- a/meta-openstack/recipes-devtools/python/python-oslo.db_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.db_git.bb
@@ -8,7 +8,7 @@ PV = "4.25.0+git${SRCPV}"
 SRCREV = "71607d59ec5c02d7beb5109c500aa9b6a0d9ee2c"
 
 SRCNAME = "oslo.db"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.i18n_3.20.0.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.i18n_3.20.0.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 SRCREV = "172e20b10981069c36b0f42377e5b4fbe22a9864"
 
 SRCNAME = "oslo.i18n"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.i18n_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.i18n_git.bb
@@ -8,7 +8,7 @@ PV = "3.17.0+git${SRCPV}"
 SRCREV = "f2729cd36f8694a6ec53a0e700599ddf4427440d"
 
 SRCNAME = "oslo.i18n"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.log_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.log_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRCNAME = "oslo.log"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "3.30.0+git${SRCPV}"
 SRCREV = "ad776e84b51223b85b7dfa85a7e77bb2f3848f4b"

--- a/meta-openstack/recipes-devtools/python/python-oslo.messaging_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.messaging_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c46f31914956e4579f9b488e71415ac8"
 
 SRCNAME = "oslo.messaging"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "5.30.1+git${SRCPV}"
 SRCREV = "a07d852b237d229a0f4dd55fd83379c0581e44e9"

--- a/meta-openstack/recipes-devtools/python/python-oslo.middleware_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.middleware_git.bb
@@ -8,7 +8,7 @@ PV = "3.30.1+git${SRCPV}"
 SRCREV = "d9ad4bae1e0d6c43a009d393ac94f7ff50116171"
 
 SRCNAME = "oslo.middleware"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.policy_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.policy_git.bb
@@ -9,7 +9,7 @@ PV = "1.25.1+git${SRCPV}"
 SRCREV = "cb9ab34cd40a7cd9eff0e40ccc2df4ee88edae4e"
 
 SRCNAME = "oslo.policy"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.privsep_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.privsep_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "oslo.privsep"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "1.22.1+git${SRCPV}"
 SRCREV = "d27bb5371c90e0f8b1bdf1bc24f16e1532b3e595"

--- a/meta-openstack/recipes-devtools/python/python-oslo.reports_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.reports_git.bb
@@ -8,7 +8,7 @@ PV = "1.22.0+git${SRCPV}"
 SRCREV = "a837f40bb0c31958d3ce99e2f9a6eb2fe651f4e6"
 
 SRCNAME = "oslo.reports"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.rootwrap_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.rootwrap_git.bb
@@ -8,7 +8,7 @@ PV = "5.9.0+git${SRCPV}"
 SRCREV = "b7b63e2ecb50ba66a1f152ae6f71dd208326fbee"
 
 SRCNAME = "oslo.rootwrap"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.serialization_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.serialization_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRCNAME = "oslo.serialization"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "2.20.0+git${SRCPV}"
 SRCREV = "e56d91427c11a3813a0154d47e804018e580086e"

--- a/meta-openstack/recipes-devtools/python/python-oslo.service_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.service_git.bb
@@ -8,7 +8,7 @@ PV = "1.25.0"
 SRCREV = "0020bef6a503905aca5cdb70aee54e1c5f2ff472"
 
 SRCNAME = "oslo.service"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.utils_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.utils_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRCNAME = "oslo.utils"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "3.28.0+git${SRCPV}"
 SRCREV = "8b3965b9bbe1e31a4939f2f69c5239d6d5c7f72c"

--- a/meta-openstack/recipes-devtools/python/python-oslo.versionedobjects_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.versionedobjects_git.bb
@@ -8,7 +8,7 @@ PV = "1.26.0+git${SRCPV}"
 SRCREV = "78cd10662f20c4ae43e20a2dfa844cfd4e5cae26"
 
 SRCNAME = "oslo.versionedobjects"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslo.vmware_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslo.vmware_git.bb
@@ -8,7 +8,7 @@ PV = "2.23.0+git${SRCPV}"
 SRCREV = "95a30dfa24d259fe16f0fd43eb1b67b9f3fc0397"
 
 SRCNAME = "oslo.vmware"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-oslotest_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-oslotest_git.bb
@@ -10,7 +10,7 @@ PV = "2.17.0+git${SRCPV}"
 SRCREV = "aea2b5cfd6442195f7ee479e21664631825af924"
 
 SRCNAME = "oslotest"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-ovsdbapp_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-ovsdbapp_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "ovsdbapp"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "0.4.1+git${SRCPV}"
 SRCREV = "742754bce3c9453f8c7186455a92e4f6d6b18ace"

--- a/meta-openstack/recipes-devtools/python/python-pika.inc
+++ b/meta-openstack/recipes-devtools/python/python-pika.inc
@@ -8,6 +8,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=fb26c37045f9e0d2c5e24b711bd7f01c"
 PV = "0.10.0+git${SRCPV}"
 SRCREV = "b907f91415169b7f590174ab5d228e75a1b273e6"
 
-SRC_URI = "git://github.com/pika/pika"
+SRC_URI = "git://github.com/pika/pika;protocol=https"
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-pycadf_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-pycadf_git.bb
@@ -8,7 +8,7 @@ PV = "1.1.0+git${SRCPV}"
 SRCREV = "c5dc0d9577e455f149edb5331a6e493def6928d5"
 
 SRCNAME = "pycadf"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-pysaml2_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-pysaml2_git.bb
@@ -8,7 +8,7 @@ PV = "3.0.2+git${SRCPV}"
 SRCREV = "248c629aa570b16fdc79c5a5eb2b3c4c0ee52916"
 
 SRCNAME = "pysaml2"
-SRC_URI = "git://github.com/rohe/${SRCNAME}.git"
+SRC_URI = "git://github.com/rohe/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-python-editor_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-python-editor_git.bb
@@ -8,7 +8,7 @@ PV = "0.4+git${SRCPV}"
 SRCREV = "d6fa2a6bb3106a1ba00fe40f9af62e4ddc539e1e"
 
 SRCNAME = "python-editor"
-SRC_URI = "git://github.com/fmoo/${SRCNAME}.git"
+SRC_URI = "git://github.com/fmoo/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-rally_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-rally_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=19cbd64715b51267a47bf3750cc6a8a5"
 PR = "r0"
 SRCNAME = "rally"
 
-SRC_URI = "git://github.com/stackforge/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/stackforge/${SRCNAME}.git;branch=master;protocol=https \
            file://rally.init \
            file://rally.conf \
            file://task-example.json \

--- a/meta-openstack/recipes-devtools/python/python-routes_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-routes_git.bb
@@ -8,7 +8,7 @@ PV = "2.4.1+git${SRCPV}"
 SRCREV = "2dcef8079cf09f427eeb0be62374f6c1a52bf59d"
 
 SRCNAME = "Routes"
-SRC_URI = "git://github.com/bbangert/routes.git"
+SRC_URI = "git://github.com/bbangert/routes.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-ryu_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-ryu_git.bb
@@ -8,7 +8,7 @@ PV = "4.19+git${SRCPV}"
 SRCREV = "51a1130f6cdcb029a51b6a75d43ac5e4cdde7072"
 
 SRCNAME = "ryu"
-SRC_URI = "git://github.com/osrg/${SRCNAME}.git"
+SRC_URI = "git://github.com/osrg/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-saharaclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-saharaclient_git.bb
@@ -20,7 +20,7 @@ RDEPENDS_${PN} += " \
 
 SRCNAME = "saharaclient"
 
-SRC_URI = "git://github.com/openstack/python-saharaclient.git;branch=master"
+SRC_URI = "git://github.com/openstack/python-saharaclient.git;branch=master;protocol=https"
 
 PV = "0.8.0+git${SRCPV}"
 SRCREV = "319ceb6acf55382218dcd971367613aecb3e4afc"

--- a/meta-openstack/recipes-devtools/python/python-swift_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-swift_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 PR = "r0"
 SRCNAME = "swift"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://proxy-server.conf \
            file://dispersion.conf \
            file://test.conf \

--- a/meta-openstack/recipes-devtools/python/python-swiftclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-swiftclient_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 PR = "r0"
 SRCNAME = "swiftclient"
 
-SRC_URI = "git://github.com/openstack/python-swiftclient.git;branch=master"
+SRC_URI = "git://github.com/openstack/python-swiftclient.git;branch=master;protocol=https"
 
 PV = "3.5.0+git${SRCPV}"
 SRCREV = "b91651eba09ed43903c55f24e3a1a52aefeea75f"

--- a/meta-openstack/recipes-devtools/python/python-trollius_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-trollius_git.bb
@@ -8,7 +8,7 @@ PV = "2.0+git${SRCPV}"
 SRCREV = "5e9854d7b7bed6eb6e182808379342355e2bfca4"
 
 SRCNAME = "trollius"
-SRC_URI = "git://github.com/haypo/${SRCNAME}.git;branch=trollius"
+SRC_URI = "git://github.com/haypo/${SRCNAME}.git;branch=trollius;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-trove_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-trove_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "trove"
 
-SRC_URI = "git://github.com/openstack/trove.git;branch=master \
+SRC_URI = "git://github.com/openstack/trove.git;branch=master;protocol=https \
           file://trove-init \
           "
 

--- a/meta-openstack/recipes-devtools/python/python-troveclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-troveclient_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 SRCNAME = "troveclient"
 
 SRC_URI = "\
-	git://github.com/openstack/python-troveclient.git;branch=master \
+	git://github.com/openstack/python-troveclient.git;branch=master;protocol=https \
 	"
 
 PV = "1.3.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-unicodecsv_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-unicodecsv_git.bb
@@ -9,7 +9,7 @@ SRCREV = "4563e33ce322f5e2dea41e76cb33dc0e008ad341"
 SRCNAME = "unicodecsv"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e71cdeaa2d2d59b225b8dfb9363fa590"
-SRC_URI = "git://github.com/jdunck/${BPN}.git"
+SRC_URI = "git://github.com/jdunck/${BPN}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-wrapt_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-wrapt_git.bb
@@ -8,7 +8,7 @@ PV = "1.10.5"
 SRCREV = "42af0563bf88e84d215dea9ea6f989cb867e930e"
 
 SRCNAME = "wrapt"
-SRC_URI = "git://github.com/GrahamDumpleton/${SRCNAME}.git"
+SRC_URI = "git://github.com/GrahamDumpleton/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-zaqarclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-zaqarclient_git.bb
@@ -28,7 +28,7 @@ RDEPENDS_${PN} +=" \
 	"
 	
 SRCNAME = "zaqarclient"
-SRC_URI = "git://github.com/openstack/${BPN}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${BPN}.git;branch=stable/pike;protocol=https"
 
 PV = "0.7.0+git${SRCPV}"
 SRCREV = "a1c2de74c56c6ddb11dc6aec78e8c438629ca8e8"

--- a/meta-openstack/recipes-devtools/python/python3-pytest-salt_2017.7.0.bb
+++ b/meta-openstack/recipes-devtools/python/python3-pytest-salt_2017.7.0.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
 
 SRCNAME = "pytest-salt"
-SRC_URI = "git://github.com/saltstack/${SRCNAME}.git;branch=master"
+SRC_URI = "git://github.com/saltstack/${SRCNAME}.git;branch=master;protocol=https"
 
 SRC_URI[md5sum] = "c598d7db87ea52cdeb067d7596b3b0b1"
 SRC_URI[sha256sum] = "7052459cda9fbdbbfff9a25b24243b0b96cf56835a2c41135d754cc5b65e2494"

--- a/meta-openstack/recipes-devtools/ruby/bundler_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/bundler_git.bb
@@ -25,7 +25,7 @@ SRCREV = "06e3647c117da210ffd15a174624497830addd7b"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/bundler/bundler.git;branch=1-7-stable \
+    git://github.com/bundler/bundler.git;branch=1-7-stable;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/chef-zero_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/chef-zero_git.bb
@@ -21,7 +21,7 @@ SRCREV = "28fe2928469885b0138de4d4270c6eccac8ab482"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/chef-zero.git;branch=master \
+    git://github.com/opscode/chef-zero.git;branch=master;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/coderay_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/coderay_git.bb
@@ -16,7 +16,7 @@ SRCREV = "a48037b85a12228431b32103786456f36beb355f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/rubychan/coderay.git \
+    git://github.com/rubychan/coderay.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/diff-lcs_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/diff-lcs_git.bb
@@ -20,7 +20,7 @@ SRCREV = "704bc2c0000b5f9bf49d607dcd0d3989b63b2595"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/halostatue/diff-lcs.git \
+    git://github.com/halostatue/diff-lcs.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/erubis_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/erubis_git.bb
@@ -16,7 +16,7 @@ SRCREV = "1f0b38d9e66885f8af0244d12d1a6702fc04a8de"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/kwatch/erubis.git \
+    git://github.com/kwatch/erubis.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/hashie_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/hashie_git.bb
@@ -16,7 +16,7 @@ SRCREV = "02df8918dd07ef2da1aceba5fd17e8757027345a"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/intridea/hashie.git \
+    git://github.com/intridea/hashie.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/highline_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/highline_git.bb
@@ -22,7 +22,7 @@ SRCREV = "327051c1c217df2880c3a53f31484f7e815e847f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/JEG2/highline.git \
+    git://github.com/JEG2/highline.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/ipaddress_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/ipaddress_git.bb
@@ -20,7 +20,7 @@ SRCREV = "96aaf68210d644157bd57a6ec3e38c49f38bfc34"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/bluemonk/ipaddress.git \
+    git://github.com/bluemonk/ipaddress.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/json_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/json_git.bb
@@ -16,7 +16,7 @@ SRCREV = "db4c71a7701b95c30f945ee1536240920dcfdc17"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/flori/json.git \
+    git://github.com/flori/json.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/method-source_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/method-source_git.bb
@@ -16,7 +16,7 @@ SRCREV = "1b1f8323a7c25f29331fe32511f50697e5405dbd"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/banister/method_source.git \
+    git://github.com/banister/method_source.git;protocol=https \
     file://gemspec-bump-version.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/mime-types_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mime-types_git.bb
@@ -19,7 +19,7 @@ SRCREV = "bc15d62118b59aabbc9cb6e5734b65bf3bc273f0"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/halostatue/mime-types.git \
+    git://github.com/halostatue/mime-types.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-authentication_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-authentication_git.bb
@@ -17,7 +17,7 @@ SRCREV = "db24a56c6f5b99114998a50942220a7023060229"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-authentication.git \
+    git://github.com/opscode/mixlib-authentication.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-cli_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-cli_git.bb
@@ -17,7 +17,7 @@ SRCREV = "b3b3c12141b5380ec61945770690fc1ae31d92b0"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-cli.git \
+    git://github.com/opscode/mixlib-cli.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-config_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-config_git.bb
@@ -17,7 +17,7 @@ SRCREV = "d7bdd7c999e13a0bd67607011731a536323dd51c"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-config.git \
+    git://github.com/opscode/mixlib-config.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-log_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-log_git.bb
@@ -17,7 +17,7 @@ SRCREV = "b750625a79cc46fffe6b886320f96e7874497fa0"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-log.git \
+    git://github.com/opscode/mixlib-log.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-shellout_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-shellout_git.bb
@@ -20,7 +20,7 @@ SRCREV = "27ba1e882dcab280527aa1764d1b45aca3ef5961"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-shellout.git \
+    git://github.com/opscode/mixlib-shellout.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/net-ssh-gateway_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/net-ssh-gateway_git.bb
@@ -20,7 +20,7 @@ SRCREV = "1de7611a7f7cedbe7a4c6cf3798c88d00637582d"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/net-ssh/net-ssh-gateway.git \
+    git://github.com/net-ssh/net-ssh-gateway.git;protocol=https \
     file://gemspec-don-t-force-the-use-of-gem-private_key.pem.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/net-ssh-multi_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/net-ssh-multi_git.bb
@@ -20,7 +20,7 @@ SRCREV = "5b668d5ef34102c9ac159a8f21c889fdc7f99f1b"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/net-ssh/net-ssh-multi.git \
+    git://github.com/net-ssh/net-ssh-multi.git;protocol=https \
     file://gemspec-don-t-force-the-use-of-gem-private_key.pem.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/net-ssh_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/net-ssh_git.bb
@@ -18,7 +18,7 @@ SRCREV = "9f8607984d8e904f211cc5edb39ab2a2ca94008e"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/net-ssh/net-ssh.git \
+    git://github.com/net-ssh/net-ssh.git;protocol=https \
     file://gemspec-don-t-force-the-use-of-gem-private_key.pem.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/ohai_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/ohai_git.bb
@@ -20,7 +20,7 @@ SRCREV = "5c166cf3fa4b2af541ee54855aae73c809044b3d"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/ohai.git \
+    git://github.com/opscode/ohai.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/pry_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/pry_git.bb
@@ -18,7 +18,7 @@ SRCREV = "191dc519813402acd6db0d7f73e652ed61f8111f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/pry/pry.git \
+    git://github.com/pry/pry.git;protocol=https \
     file://rdoc-fixup-opt.banner-heredoc.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/rack_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/rack_git.bb
@@ -20,7 +20,7 @@ SRCREV = "134d6218d0881d87ae6a522e88eafbddb6cd1bb7"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/rack/rack.git;branch=1-6-stable \
+    git://github.com/rack/rack.git;branch=1-6-stable;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/rest-client_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/rest-client_git.bb
@@ -18,7 +18,7 @@ SRCREV = "40eddc184a7b3fe79f9b68f291e06df4c1fbcb0b"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/rest-client/rest-client.git \
+    git://github.com/rest-client/rest-client.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/slop_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/slop_git.bb
@@ -16,7 +16,7 @@ SRCREV = "50c4d5a6553c9d0b78dee35a092ea3a40c136fa1"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/leejarvis/slop.git \
+    git://github.com/leejarvis/slop.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/systemu_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/systemu_git.bb
@@ -17,7 +17,7 @@ SRCREV = "cb253a8bf213beea69f27418202e936a22d7308f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/ahoward/systemu.git \
+    git://github.com/ahoward/systemu.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/yajl-ruby_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/yajl-ruby_git.bb
@@ -17,7 +17,7 @@ SRCREV = "d8a0b8d5c879b0810b43eaab241fb87b68c93453"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/brianmario/yajl-ruby.git \
+    git://github.com/brianmario/yajl-ruby.git;protocol=https \
     file://0001-Don-t-compile-extensions.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/yard_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/yard_git.bb
@@ -20,7 +20,7 @@ SRCREV = "d83194e1a09098ec5be28b616cde3b9a15380873"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/lsegal/yard.git \
+    git://github.com/lsegal/yard.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-extended/novnc/novnc_git.bb
+++ b/meta-openstack/recipes-extended/novnc/novnc_git.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=ac06308a999996ffc2d24d81b3a39f1b"
 SRCREV = "8f12ca7a5a64144fe548cada332d5d19ef26a1fe"
 PV = "0.4+git${SRCPV}"
 
-SRC_URI = "git://github.com/kanaka/noVNC.git"
+SRC_URI = "git://github.com/kanaka/noVNC.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-extended/tempest/tempest_git.bb
+++ b/meta-openstack/recipes-extended/tempest/tempest_git.bb
@@ -9,7 +9,7 @@ SRCNAME = "tempest"
 
 inherit setuptools identity hosts
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://tempest.conf \
            file://logging.conf \
 "

--- a/meta-openstack/recipes-extended/uwsgi/uwsgi_git.bb
+++ b/meta-openstack/recipes-extended/uwsgi/uwsgi_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=33ab1ce13e2312dddfad07f97f66321f"
 
 SRCNAME = "uwsgi"
-SRC_URI = "git://github.com/unbit/uwsgi.git;branch=uwsgi-2.0 \
+SRC_URI = "git://github.com/unbit/uwsgi.git;branch=uwsgi-2.0;protocol=https \
     file://Add-explicit-breaks-to-avoid-implicit-passthrough.patch \
     file://more-Add-explicit-breaks-to-avoid-implicit-passthrough.patch \
 "

--- a/meta-openstack/recipes-support/chef/chef_git.bb
+++ b/meta-openstack/recipes-support/chef/chef_git.bb
@@ -18,7 +18,7 @@ SRCREV = "1dc20627aa5d742376269dc5b4d5c67f34d08008"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/chef.git;branch=12.4-stable \
+    git://github.com/opscode/chef.git;branch=12.4-stable;protocol=https \
     file://0001-chang-ksh-to-sh.patch \
     "
 

--- a/meta-openstack/recipes-support/mod-wsgi/mod-wsgi_git.bb
+++ b/meta-openstack/recipes-support/mod-wsgi/mod-wsgi_git.bb
@@ -16,7 +16,7 @@ S = "${WORKDIR}/git"
 
 SRCNAME = "mod_wsgi"
 SRC_URI = "\
-	git://github.com/GrahamDumpleton/mod_wsgi.git \
+	git://github.com/GrahamDumpleton/mod_wsgi.git;protocol=https \
 	file://configure.ac-allow-PYTHON-values-to-be-passed-via-en.patch \        
 	"
 

--- a/meta-openstack/recipes-support/tgt/tgt_git.bb
+++ b/meta-openstack/recipes-support/tgt/tgt_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "sg3-utils"
 SRCREV = "cb7971cfeecaa43c15eed4719dc82516d7e87b6c"
 PV = "1.0.67+git${SRCPV}"
 
-SRC_URI = "git://github.com/fujita/tgt.git \
+SRC_URI = "git://github.com/fujita/tgt.git;protocol=https \
 	file://0001-Correct-the-path-of-header-files-check-in-Yocto-buil.patch \
         file://0001-usr-Makefile-WARNING-fix.patch \
         file://usr-Makefile-apply-LDFLAGS-to-all-executables.patch \

--- a/recipes-support/puppet-vswitch/puppet-vswitch_git.bb
+++ b/recipes-support/puppet-vswitch/puppet-vswitch_git.bb
@@ -7,7 +7,7 @@ PV = "3.0.0"
 SRCREV = "c374840910c823f7669cf2e1229c7df7192ae880"
 
 SRC_URI = " \
-    git://github.com/openstack/puppet-vswitch.git;branch=master \
+    git://github.com/openstack/puppet-vswitch.git;branch=master;protocol=https \
     file://Add-gemspec.patch \
 "
 

--- a/recipes-support/puppetlabs-stdlib/puppetlabs-stdlib_git.bb
+++ b/recipes-support/puppetlabs-stdlib/puppetlabs-stdlib_git.bb
@@ -7,7 +7,7 @@ PV = "4.10.0"
 SRCREV = "0b4822be3d2242e83c28ab7fed6c5817adc322d5"
 
 SRC_URI = " \
-    git://github.com/puppetlabs/puppetlabs-stdlib.git;branch=master \
+    git://github.com/puppetlabs/puppetlabs-stdlib.git;branch=master;protocol=https \
     file://Add-gemspec.patch \
 "
 

--- a/recipes-support/ruby-shadow/ruby-shadow_git.bb
+++ b/recipes-support/ruby-shadow/ruby-shadow_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=137882914e5269b7268f0fe8e28a3f89"
 
 PV = "2.4.1"
 
-SRC_URI = "git://github.com/apalmblad/ruby-shadow.git"
+SRC_URI = "git://github.com/apalmblad/ruby-shadow.git;protocol=https"
 SRCREV = "4231a4838fd50022b112838f114ee0586e119605"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 