### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/meta-openstack/recipes-devtools/python/python-barbican_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-barbican_git.bb
@@ -8,7 +8,7 @@ PR = "r0"
 SRCNAME = "barbican"
 BARBICAN_MAX_PACKET_SIZE ?= "65535"
 
-SRC_URI = "git://github.com/openstack/barbican.git;branch=master \
+SRC_URI = "git://github.com/openstack/barbican.git;branch=master;protocol=https \
            file://barbican.init \
            file://barbican-increase-buffer-size-to-support-PKI-tokens.patch \
            file://barbican-fix-path-to-find-configuration-files.patch \

--- a/meta-openstack/recipes-devtools/python/python-ceilometer_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-ceilometer_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "ceilometer"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://ceilometer.conf \
            file://ceilometer.init \
            file://fix_ceilometer_memory_leak.patch \

--- a/meta-openstack/recipes-devtools/python/python-cinder_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-cinder_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "cinder"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
     file://cinder-init \
     file://cinder-init.service \
     file://cinder-api.service \

--- a/meta-openstack/recipes-devtools/python/python-cinderclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-cinderclient_git.bb
@@ -8,7 +8,7 @@ DEPENDS = "python-setuptools3-git"
 SRCNAME = "python-cinderclient"
 
 SRC_URI = "\
-	git://github.com/openstack/python-cinderclient.git;branch=stable/pike \
+	git://github.com/openstack/python-cinderclient.git;branch=stable/pike;protocol=https \
 	file://cinder-api-check.sh \
 	"
 

--- a/meta-openstack/recipes-devtools/python/python-glance_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-glance_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "glance"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://glance.init \
            file://glance-api.service \
            file://glance-registry.service \

--- a/meta-openstack/recipes-devtools/python/python-glanceclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-glanceclient_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/openstack/python-glanceclient"
 SECTION = "devel/python"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
-SRC_URI = "git://github.com/openstack/python-glanceclient.git \
+SRC_URI = "git://github.com/openstack/python-glanceclient.git;protocol=https \
            file://glance-api-check.sh \
         "
 

--- a/meta-openstack/recipes-devtools/python/python-glancestore_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-glancestore_git.bb
@@ -8,7 +8,7 @@ SRCREV = "c816b38d9f12be75d989409cbab6dfefa8f49dc3"
 PV = "0.9.1+git${SRCPV}"
 
 SRC_URI = "\
-	git://github.com/openstack/glance_store.git \
+	git://github.com/openstack/glance_store.git;protocol=https \
 	"
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-heat_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-heat_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "heat"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://heat.conf \
            file://heat.init \
            file://autoscaling_example.template \

--- a/meta-openstack/recipes-devtools/python/python-heatclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-heatclient_git.bb
@@ -27,7 +27,7 @@ RDEPENDS_${PN} +="python-cliff \
 PR = "r0"
 SRCNAME = "heatclient"
 
-SRC_URI = "git://github.com/openstack/python-heatclient.git;branch=master"
+SRC_URI = "git://github.com/openstack/python-heatclient.git;branch=master;protocol=https"
 
 PV = "1.17.0+git${SRCPV}"
 SRCREV = "8af5deb458d51f4ec16e769d7fd6c94655f82f5f"

--- a/meta-openstack/recipes-devtools/python/python-horizon_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-horizon_git.bb
@@ -78,7 +78,7 @@ RDEPENDS_${PN} += " \
 
 SRCNAME = "horizon"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
     file://wsgi-horizon.conf \
     file://fix_bindir_path.patch \
     file://local_settings.py \

--- a/meta-openstack/recipes-devtools/python/python-keystone-hybrid-backend_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-keystone-hybrid-backend_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://hybrid_identity.py;beginline=1;endline=14;md5=06c14f6
 
 PR = "r0"
 
-SRC_URI = "git://github.com/SUSE-Cloud/keystone-hybrid-backend.git;branch=havana"
+SRC_URI = "git://github.com/SUSE-Cloud/keystone-hybrid-backend.git;branch=havana;protocol=https"
 
 PV="git${SRCPV}"
 SRCREV="0bd376242f8522edef7031d2339b9533b86c17aa"

--- a/meta-openstack/recipes-devtools/python/python-keystone_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-keystone_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "keystone"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://keystone-init \
            file://keystone-init.service \
            file://keystone.conf \

--- a/meta-openstack/recipes-devtools/python/python-neutron_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-neutron_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "neutron"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://neutron-server.service \
            file://neutron.conf \
            file://l3_agent.ini \

--- a/meta-openstack/recipes-devtools/python/python-neutronclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-neutronclient_git.bb
@@ -34,7 +34,7 @@ RDEPENDS_${PN} += " \
         bash \
         "
 
-SRC_URI = "git://github.com/openstack/python-neutronclient.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/python-neutronclient.git;branch=stable/pike;protocol=https \
            file://neutronclient-use-csv-flag-instead-of-json.patch \
            file://neutron-api-check.sh \
           "

--- a/meta-openstack/recipes-devtools/python/python-nova_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-nova_git.bb
@@ -13,7 +13,7 @@ SRCNAME = "nova"
 
 FILESEXTRAPATHS_append := "${THISDIR}/${PN}"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https \
            file://neutron-api-set-default-binding-vnic_type.patch \
            "
 

--- a/meta-openstack/recipes-devtools/python/python-novaclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-novaclient_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7cdb54622cacc9bc9b2883091e6dd669"
 
 SRC_URI = "\
-	git://github.com/openstack/python-novaclient.git;branch=stable/pike \
+	git://github.com/openstack/python-novaclient.git;branch=stable/pike;protocol=https \
 	file://nova-api-check.sh \
 	"
 

--- a/meta-openstack/recipes-devtools/python/python-novnc_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-novnc_git.bb
@@ -10,7 +10,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=6458695fb66dcd893becb5f9f912715e"
 SRCREV = "3b8ec46fd26d644e6edbea4f46e630929297e448"
 PV = "0.5.1+git${SRCPV}"
 
-SRC_URI = "git://github.com/kanaka/noVNC.git \
+SRC_URI = "git://github.com/kanaka/noVNC.git;protocol=https \
            file://python-distutils.patch"
 
 S = "${WORKDIR}/git"

--- a/meta-openstack/recipes-devtools/python/python-openstackclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-openstackclient_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI = " \
-        git://github.com/openstack/python-openstackclient.git;branch=stable/pike \
+        git://github.com/openstack/python-openstackclient.git;branch=stable/pike;protocol=https \
         "
 
 PV = "3.12.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python-os-client-config.inc
+++ b/meta-openstack/recipes-devtools/python/python-os-client-config.inc
@@ -8,7 +8,7 @@ PV = "1.28.0"
 SRCREV = "261c05f0057d556a8910457f1e22ca4d81801081"
 
 SRCNAME = "os-client-config"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-rally_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-rally_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=19cbd64715b51267a47bf3750cc6a8a5"
 PR = "r0"
 SRCNAME = "rally"
 
-SRC_URI = "git://github.com/stackforge/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/stackforge/${SRCNAME}.git;branch=master;protocol=https \
            file://rally.init \
            file://rally.conf \
            file://task-example.json \

--- a/meta-openstack/recipes-devtools/python/python-ryu_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-ryu_git.bb
@@ -8,7 +8,7 @@ PV = "4.19+git${SRCPV}"
 SRCREV = "51a1130f6cdcb029a51b6a75d43ac5e4cdde7072"
 
 SRCNAME = "ryu"
-SRC_URI = "git://github.com/osrg/${SRCNAME}.git"
+SRC_URI = "git://github.com/osrg/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python-swift_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-swift_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 PR = "r0"
 SRCNAME = "swift"
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://proxy-server.conf \
            file://dispersion.conf \
            file://test.conf \

--- a/meta-openstack/recipes-devtools/python/python-trove_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-trove_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "trove"
 
-SRC_URI = "git://github.com/openstack/trove.git;branch=master \
+SRC_URI = "git://github.com/openstack/trove.git;branch=master;protocol=https \
           file://trove-init \
           "
 

--- a/meta-openstack/recipes-devtools/python/python-troveclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python-troveclient_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 SRCNAME = "troveclient"
 
 SRC_URI = "\
-	git://github.com/openstack/python-troveclient.git;branch=master \
+	git://github.com/openstack/python-troveclient.git;branch=master;protocol=https \
 	"
 
 PV = "3.0.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python3-barbicanclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-barbicanclient_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e031cff4528978748f9cc064c6e6fa73"
 
 SRC_URI = "\
-	git://github.com/openstack/python-barbicanclient.git \
+	git://github.com/openstack/python-barbicanclient.git;protocol=https \
 	"
 
 PV = "5.0.1+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python3-kafka_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-kafka_git.bb
@@ -9,7 +9,7 @@ SRCREV = "5bb126bf20bbb5baeb4e9afc48008dbe411631bc"
 SRCNAME = "kafka-python"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=22efebb1e053dcc946f4b9d17f3cbbea"
-SRC_URI = "git://github.com/mumrah/${SRCNAME}.git"
+SRC_URI = "git://github.com/mumrah/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-keystoneclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-keystoneclient_git.bb
@@ -9,7 +9,7 @@ SRCNAME = "keystoneclient"
 SRC_URI = "file://keystone-api-check.sh"
 
 SRC_URI = "\
-        git://github.com/openstack/python-keystoneclient.git;branch=stable/pike \
+        git://github.com/openstack/python-keystoneclient.git;branch=stable/pike;protocol=https \
         file://keystone-api-check.sh \
         "
 

--- a/meta-openstack/recipes-devtools/python/python3-memcached_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-memcached_git.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://PSF.LICENSE;md5=7dd786e8594f1e787da94a946557b40e"
 PV = "1.59+git${SRCPV}"
 SRCREV = "959e068fec8b4c956b0d82269336818e667726e7"
 
-SRC_URI = "git://github.com/linsomniac/python-memcached.git"
+SRC_URI = "git://github.com/linsomniac/python-memcached.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-microversion-parse_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-microversion-parse_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
 SRC_URI = "\
-	git://github.com/openstack/microversion-parse.git;branch=master \
+	git://github.com/openstack/microversion-parse.git;branch=master;protocol=https \
 	"
 
 PV = "1.0.1+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python3-openstacksdk_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-openstacksdk_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRC_URI = " \
-        git://github.com/openstack/python-openstacksdk.git;branch=master \
+        git://github.com/openstack/python-openstacksdk.git;branch=master;protocol=https \
         "
 
 PV = "0.52.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python3-os-brick_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-os-brick_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI = "\
-	git://github.com/openstack/os-brick.git;branch=stable/victoria \
+	git://github.com/openstack/os-brick.git;branch=stable/victoria;protocol=https \
 	"
 SRCREV = "f0cf77672fed70f20896c23015cb50341f311f38"
 

--- a/meta-openstack/recipes-devtools/python/python3-os-vif_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-os-vif_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRC_URI = "\
-	git://github.com/openstack/os-vif.git \
+	git://github.com/openstack/os-vif.git;protocol=https \
 	"
 
 PV = "2.2.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python3-os-win_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-os-win_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRC_URI = "\
-	git://github.com/openstack/os-win.git \
+	git://github.com/openstack/os-win.git;protocol=https \
 	"
 
 PV = "5.1.0+git${SRCPV}"

--- a/meta-openstack/recipes-devtools/python/python3-oslo.cache_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.cache_git.bb
@@ -8,7 +8,7 @@ PV = "2.6.1+git${SRCPV}"
 SRCREV = "df075b2465195de53e42897e7d9be6c6c375ce5e"
 
 SRCNAME = "oslo.cache"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.concurrency_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.concurrency_git.bb
@@ -8,7 +8,7 @@ PV = "3.21.2+git${SRCPV}"
 SRCREV = "1b25351d1c63e573068fff3d16faca440bbdcabf"
 
 SRCNAME = "oslo.concurrency"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.context_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.context_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "oslo.context"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "2.17.0+git${SRCPV}"
 SRCREV = "f4b6914db02e6bcf0de4a97bbc3dc85dd6e06d91"

--- a/meta-openstack/recipes-devtools/python/python3-oslo.db_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.db_git.bb
@@ -8,7 +8,7 @@ PV = "8.4.0+git${SRCPV}"
 SRCREV = "e42c73343f640eaacb0a76d204eb55c85de4f5d5"
 
 SRCNAME = "oslo.db"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.i18n_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.i18n_git.bb
@@ -8,7 +8,7 @@ PV = "5.0.1+git${SRCPV}"
 SRCREV = "73187bd86903fc87665a829c9a0c714db6aa3022"
 
 SRCNAME = "oslo.i18n"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 inherit setuptools3
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.log_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.log_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRCNAME = "oslo.log"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "3.30.3+git${SRCPV}"
 SRCREV = "76d1dee7b80c62172ea3900b75a47edf5b64cab4"

--- a/meta-openstack/recipes-devtools/python/python3-oslo.messaging_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.messaging_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c46f31914956e4579f9b488e71415ac8"
 
 SRCNAME = "oslo.messaging"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 PV = "12.5.0+git${SRCPV}"
 SRCREV = "62e104bdb57714a0754f788795d1b4faf8ebb74d"

--- a/meta-openstack/recipes-devtools/python/python3-oslo.middleware_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.middleware_git.bb
@@ -8,7 +8,7 @@ PV = "4.1.0+git${SRCPV}"
 SRCREV = "7355d905bc0e6b7d8884e290cc26895eed0f7179"
 
 SRCNAME = "oslo.middleware"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.policy_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.policy_git.bb
@@ -9,7 +9,7 @@ PV = "3.3.0+git${SRCPV}"
 SRCREV = "cab28649c689067970a51a2f9b329bdd6a0f0501"
 
 SRCNAME = "oslo.policy"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.privsep_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.privsep_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "oslo.privsep"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 PV = "2.4.0+git${SRCPV}"
 SRCREV = "512b5d9f6b79b798474d8bb2dac2462b0f705cb9"

--- a/meta-openstack/recipes-devtools/python/python3-oslo.reports_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.reports_git.bb
@@ -8,7 +8,7 @@ PV = "2.2.0+git${SRCPV}"
 SRCREV = "bc631aedef131bc45225720e5c8f8e4ca35ff020"
 
 SRCNAME = "oslo.reports"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.rootwrap_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.rootwrap_git.bb
@@ -8,7 +8,7 @@ PV = "6.1.0+git${SRCPV}"
 SRCREV = "ff61e1577c3aaec6242951876263108559d1a203"
 
 SRCNAME = "oslo.rootwrap"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.serialization_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.serialization_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRCNAME = "oslo.serialization"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "2.20.0+git${SRCPV}"
 SRCREV = "e56d91427c11a3813a0154d47e804018e580086e"

--- a/meta-openstack/recipes-devtools/python/python3-oslo.service_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.service_git.bb
@@ -8,7 +8,7 @@ PV = "1.25.2"
 SRCREV = "8481ce67951aa1b44203c03639b79e06f65bd8bc"
 
 SRCNAME = "oslo.service"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.utils_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.utils_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
 
 SRCNAME = "oslo.utils"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "3.28.0+git${SRCPV}"
 SRCREV = "8b3965b9bbe1e31a4939f2f69c5239d6d5c7f72c"

--- a/meta-openstack/recipes-devtools/python/python3-oslo.versionedobjects_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.versionedobjects_git.bb
@@ -8,7 +8,7 @@ PV = "2.3.0+git${SRCPV}"
 SRCREV = "8db69628834332ed2df6690135be5d5c1ebd3ca1"
 
 SRCNAME = "oslo.versionedobjects"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslo.vmware_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslo.vmware_git.bb
@@ -8,7 +8,7 @@ PV = "3.4.0+git${SRCPV}"
 SRCREV = "32c8d43a20cb6a29f03324fbc2e6cad3bfb5a294"
 
 SRCNAME = "oslo.vmware"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-oslotest_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-oslotest_git.bb
@@ -10,7 +10,7 @@ PV = "2.17.2+git${SRCPV}"
 SRCREV = "54ac29c3edd46530c1ee90eb860a7e686d9a3740"
 
 SRCNAME = "oslotest"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-ovsdbapp_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-ovsdbapp_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1dece7821bf3fd70fe1309eaa37d52a2"
 
 SRCNAME = "ovsdbapp"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=stable/pike;protocol=https"
 
 PV = "0.4.4+git${SRCPV}"
 SRCREV = "40064ca2d99389f278028508a17f2e38d6df6f10"

--- a/meta-openstack/recipes-devtools/python/python3-pycadf_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-pycadf_git.bb
@@ -8,7 +8,7 @@ PV = "3.1.0+git${SRCPV}"
 SRCREV = "2402013a8719873d65136fc283e1855166adbc26"
 
 SRCNAME = "pycadf"
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git"
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/python/python3-saharaclient_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-saharaclient_git.bb
@@ -22,7 +22,7 @@ SRCNAME = "saharaclient"
 
 inherit setuptools3
 
-SRC_URI = "git://github.com/openstack/python-saharaclient.git;branch=master"
+SRC_URI = "git://github.com/openstack/python-saharaclient.git;branch=master;protocol=https"
 
 PV = "3.2.1+git${SRCPV}"
 SRCREV = "a9fee07108c432e20a3ca7760541d4fcb4f14811"

--- a/meta-openstack/recipes-devtools/python/python3-salttesting_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-salttesting_git.bb
@@ -4,7 +4,7 @@ SECTION = "devel/python"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f36f1e9e3e30f90180efdf7e40d943e5"
 
-SRC_URI = "git://github.com/saltstack/salt-testing.git;branch=develop \
+SRC_URI = "git://github.com/saltstack/salt-testing.git;branch=develop;protocol=https \
            file://0001-Add-ptest-output-option-to-test-suite.patch \
            "
 

--- a/meta-openstack/recipes-devtools/python/python3-trollius_git.bb
+++ b/meta-openstack/recipes-devtools/python/python3-trollius_git.bb
@@ -8,7 +8,7 @@ PV = "3.4.3+git${SRCPV}"
 SRCREV = "7b2d8abfce1d7ef18ef516f9b1b7032172630375"
 
 SRCNAME = "trollius"
-SRC_URI = "git://github.com/haypo/${SRCNAME}.git;branch=trollius"
+SRC_URI = "git://github.com/haypo/${SRCNAME}.git;branch=trollius;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-devtools/ruby/bundler_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/bundler_git.bb
@@ -25,7 +25,7 @@ SRCREV = "06e3647c117da210ffd15a174624497830addd7b"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/bundler/bundler.git;branch=1-7-stable \
+    git://github.com/bundler/bundler.git;branch=1-7-stable;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/chef-zero_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/chef-zero_git.bb
@@ -21,7 +21,7 @@ SRCREV = "28fe2928469885b0138de4d4270c6eccac8ab482"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/chef-zero.git;branch=master \
+    git://github.com/opscode/chef-zero.git;branch=master;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/coderay_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/coderay_git.bb
@@ -16,7 +16,7 @@ SRCREV = "a48037b85a12228431b32103786456f36beb355f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/rubychan/coderay.git \
+    git://github.com/rubychan/coderay.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/diff-lcs_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/diff-lcs_git.bb
@@ -20,7 +20,7 @@ SRCREV = "704bc2c0000b5f9bf49d607dcd0d3989b63b2595"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/halostatue/diff-lcs.git \
+    git://github.com/halostatue/diff-lcs.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/erubis_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/erubis_git.bb
@@ -16,7 +16,7 @@ SRCREV = "1f0b38d9e66885f8af0244d12d1a6702fc04a8de"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/kwatch/erubis.git \
+    git://github.com/kwatch/erubis.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/hashie_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/hashie_git.bb
@@ -16,7 +16,7 @@ SRCREV = "02df8918dd07ef2da1aceba5fd17e8757027345a"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/intridea/hashie.git \
+    git://github.com/intridea/hashie.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/highline_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/highline_git.bb
@@ -22,7 +22,7 @@ SRCREV = "327051c1c217df2880c3a53f31484f7e815e847f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/JEG2/highline.git \
+    git://github.com/JEG2/highline.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/ipaddress_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/ipaddress_git.bb
@@ -20,7 +20,7 @@ SRCREV = "96aaf68210d644157bd57a6ec3e38c49f38bfc34"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/ipaddress-gem/ipaddress.git \
+    git://github.com/ipaddress-gem/ipaddress.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/json_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/json_git.bb
@@ -16,7 +16,7 @@ SRCREV = "4cf6c6270f52888997ec1b626b9f557db4f26f2e"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/flori/json.git;branch=v1.8 \
+    git://github.com/flori/json.git;branch=v1.8;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/method-source_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/method-source_git.bb
@@ -16,7 +16,7 @@ SRCREV = "1b1f8323a7c25f29331fe32511f50697e5405dbd"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/banister/method_source.git \
+    git://github.com/banister/method_source.git;protocol=https \
     file://gemspec-bump-version.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/mime-types_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mime-types_git.bb
@@ -19,7 +19,7 @@ SRCREV = "bc15d62118b59aabbc9cb6e5734b65bf3bc273f0"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/halostatue/mime-types.git \
+    git://github.com/halostatue/mime-types.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-authentication_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-authentication_git.bb
@@ -17,7 +17,7 @@ SRCREV = "db24a56c6f5b99114998a50942220a7023060229"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-authentication.git \
+    git://github.com/opscode/mixlib-authentication.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-cli_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-cli_git.bb
@@ -17,7 +17,7 @@ SRCREV = "b3b3c12141b5380ec61945770690fc1ae31d92b0"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-cli.git \
+    git://github.com/opscode/mixlib-cli.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-config_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-config_git.bb
@@ -17,7 +17,7 @@ SRCREV = "d7bdd7c999e13a0bd67607011731a536323dd51c"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-config.git \
+    git://github.com/opscode/mixlib-config.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-log_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-log_git.bb
@@ -17,7 +17,7 @@ SRCREV = "b750625a79cc46fffe6b886320f96e7874497fa0"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-log.git \
+    git://github.com/opscode/mixlib-log.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/mixlib-shellout_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/mixlib-shellout_git.bb
@@ -20,7 +20,7 @@ SRCREV = "27ba1e882dcab280527aa1764d1b45aca3ef5961"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/mixlib-shellout.git \
+    git://github.com/opscode/mixlib-shellout.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/net-ssh-gateway_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/net-ssh-gateway_git.bb
@@ -20,7 +20,7 @@ SRCREV = "1de7611a7f7cedbe7a4c6cf3798c88d00637582d"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/net-ssh/net-ssh-gateway.git \
+    git://github.com/net-ssh/net-ssh-gateway.git;protocol=https \
     file://gemspec-don-t-force-the-use-of-gem-private_key.pem.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/net-ssh-multi_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/net-ssh-multi_git.bb
@@ -20,7 +20,7 @@ SRCREV = "5b668d5ef34102c9ac159a8f21c889fdc7f99f1b"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/net-ssh/net-ssh-multi.git \
+    git://github.com/net-ssh/net-ssh-multi.git;protocol=https \
     file://gemspec-don-t-force-the-use-of-gem-private_key.pem.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/net-ssh_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/net-ssh_git.bb
@@ -18,7 +18,7 @@ SRCREV = "9f8607984d8e904f211cc5edb39ab2a2ca94008e"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/net-ssh/net-ssh.git \
+    git://github.com/net-ssh/net-ssh.git;protocol=https \
     file://gemspec-don-t-force-the-use-of-gem-private_key.pem.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/ohai_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/ohai_git.bb
@@ -20,7 +20,7 @@ SRCREV = "5c166cf3fa4b2af541ee54855aae73c809044b3d"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/ohai.git \
+    git://github.com/opscode/ohai.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/pry_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/pry_git.bb
@@ -18,7 +18,7 @@ SRCREV = "191dc519813402acd6db0d7f73e652ed61f8111f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/pry/pry.git \
+    git://github.com/pry/pry.git;protocol=https \
     file://rdoc-fixup-opt.banner-heredoc.patch \
     "
 

--- a/meta-openstack/recipes-devtools/ruby/rack_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/rack_git.bb
@@ -20,7 +20,7 @@ SRCREV = "134d6218d0881d87ae6a522e88eafbddb6cd1bb7"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/rack/rack.git;branch=1-6-stable \
+    git://github.com/rack/rack.git;branch=1-6-stable;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/rest-client_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/rest-client_git.bb
@@ -18,7 +18,7 @@ SRCREV = "40eddc184a7b3fe79f9b68f291e06df4c1fbcb0b"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/rest-client/rest-client.git \
+    git://github.com/rest-client/rest-client.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/slop_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/slop_git.bb
@@ -16,7 +16,7 @@ SRCREV = "50c4d5a6553c9d0b78dee35a092ea3a40c136fa1"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/leejarvis/slop.git \
+    git://github.com/leejarvis/slop.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/systemu_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/systemu_git.bb
@@ -17,7 +17,7 @@ SRCREV = "cb253a8bf213beea69f27418202e936a22d7308f"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/ahoward/systemu.git \
+    git://github.com/ahoward/systemu.git;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-devtools/ruby/yard_git.bb
+++ b/meta-openstack/recipes-devtools/ruby/yard_git.bb
@@ -20,7 +20,7 @@ SRCREV = "d83194e1a09098ec5be28b616cde3b9a15380873"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/lsegal/yard.git;branch=main \
+    git://github.com/lsegal/yard.git;branch=main;protocol=https \
     "
 
 inherit ruby

--- a/meta-openstack/recipes-extended/novnc/novnc_git.bb
+++ b/meta-openstack/recipes-extended/novnc/novnc_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=b428e7772bf00c07fb7b863b80358adf"
 SRCREV = "9142f8f0f7b4a53447f5cfec3a797cbf0d6204a9"
 PV = "1.2.0+git${SRCPV}"
 
-SRC_URI = "git://github.com/kanaka/noVNC.git"
+SRC_URI = "git://github.com/kanaka/noVNC.git;protocol=https"
 
 S = "${WORKDIR}/git"
 

--- a/meta-openstack/recipes-extended/tempest/tempest_git.bb
+++ b/meta-openstack/recipes-extended/tempest/tempest_git.bb
@@ -9,7 +9,7 @@ SRCNAME = "tempest"
 
 inherit setuptools3 identity hosts
 
-SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master \
+SRC_URI = "git://github.com/openstack/${SRCNAME}.git;branch=master;protocol=https \
            file://tempest.conf \
            file://logging.conf \
 "

--- a/meta-openstack/recipes-extended/uwsgi/uwsgi_git.bb
+++ b/meta-openstack/recipes-extended/uwsgi/uwsgi_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=33ab1ce13e2312dddfad07f97f66321f"
 
 SRCNAME = "uwsgi"
-SRC_URI = "git://github.com/unbit/uwsgi.git;branch=uwsgi-2.0 \
+SRC_URI = "git://github.com/unbit/uwsgi.git;branch=uwsgi-2.0;protocol=https \
     file://Add-explicit-breaks-to-avoid-implicit-passthrough.patch \
     file://more-Add-explicit-breaks-to-avoid-implicit-passthrough.patch \
 "

--- a/meta-openstack/recipes-support/chef/chef_git.bb
+++ b/meta-openstack/recipes-support/chef/chef_git.bb
@@ -18,7 +18,7 @@ SRCREV = "1dc20627aa5d742376269dc5b4d5c67f34d08008"
 S = "${WORKDIR}/git"
 
 SRC_URI = " \
-    git://github.com/opscode/chef.git;branch=12.4-stable \
+    git://github.com/opscode/chef.git;branch=12.4-stable;protocol=https \
     file://0001-chang-ksh-to-sh.patch \
     "
 

--- a/meta-openstack/recipes-support/mod-wsgi/mod-wsgi_git.bb
+++ b/meta-openstack/recipes-support/mod-wsgi/mod-wsgi_git.bb
@@ -16,7 +16,7 @@ S = "${WORKDIR}/git"
 
 SRCNAME = "mod_wsgi"
 SRC_URI = "\
-	git://github.com/GrahamDumpleton/mod_wsgi.git \
+	git://github.com/GrahamDumpleton/mod_wsgi.git;protocol=https \
 	file://configure.ac-allow-PYTHON-values-to-be-passed-via-en.patch \        
 	"
 

--- a/meta-openstack/recipes-support/tgt/tgt_git.bb
+++ b/meta-openstack/recipes-support/tgt/tgt_git.bb
@@ -7,7 +7,7 @@ DEPENDS = "sg3-utils libaio"
 SRCREV = "b43dbc6711e43c0a32cc4d9df22884841d911d51"
 PV = "1.0.79+git${SRCPV}"
 
-SRC_URI = "git://github.com/fujita/tgt.git \
+SRC_URI = "git://github.com/fujita/tgt.git;protocol=https \
 	file://0001-Correct-the-path-of-header-files-check-in-Yocto-buil.patch \
         file://0001-usr-Makefile-WARNING-fix.patch \
         file://usr-Makefile-apply-LDFLAGS-to-all-executables.patch \

--- a/recipes-connectivity/consul/consul-migrate_git.bb
+++ b/recipes-connectivity/consul/consul-migrate_git.bb
@@ -18,13 +18,13 @@ SRCREV_bolt = "c6ba97b89e0454fec9aa92e1d33a4e2c5fc1f631"
 SRCREV_go-msgpack = "fa3f63826f7c23912c15263591e65d54d080b458"
 
 SRC_URI += " \
-   git://github.com/hashicorp/raft;name=raft;destsuffix=git/src/github.com/hashicorp/raft \
-   git://github.com/armon/go-metrics;name=go-metrics;destsuffix=git/src/github.com/armon/go-metrics \
-   git://github.com/hashicorp/raft-boltdb;name=raft-boltdb;destsuffix=git/src/github.com/hashicorp/raft-boltdb \
-   git://github.com/hashicorp/raft-mdb;name=raft-mdb;destsuffix=git/src/github.com/hashicorp/raft-mdb \
-   git://github.com/armon/gomdb;name=gomdb;destsuffix=git/src/github.com/armon/gomdb \
-   git://github.com/boltdb/bolt;name=bolt;destsuffix=git/src/github.com/boltdb/bolt \
-   git://github.com/hashicorp/go-msgpack;name=go-msgpack;destsuffix=git/src/github.com/hashicorp/go-msgpack \
+   git://github.com/hashicorp/raft;name=raft;destsuffix=git/src/github.com/hashicorp/raft;protocol=https \
+   git://github.com/armon/go-metrics;name=go-metrics;destsuffix=git/src/github.com/armon/go-metrics;protocol=https \
+   git://github.com/hashicorp/raft-boltdb;name=raft-boltdb;destsuffix=git/src/github.com/hashicorp/raft-boltdb;protocol=https \
+   git://github.com/hashicorp/raft-mdb;name=raft-mdb;destsuffix=git/src/github.com/hashicorp/raft-mdb;protocol=https \
+   git://github.com/armon/gomdb;name=gomdb;destsuffix=git/src/github.com/armon/gomdb;protocol=https \
+   git://github.com/boltdb/bolt;name=bolt;destsuffix=git/src/github.com/boltdb/bolt;protocol=https \
+   git://github.com/hashicorp/go-msgpack;name=go-msgpack;destsuffix=git/src/github.com/hashicorp/go-msgpack;protocol=https \
 "
 
 inherit go

--- a/recipes-support/puppet-vswitch/puppet-vswitch_git.bb
+++ b/recipes-support/puppet-vswitch/puppet-vswitch_git.bb
@@ -7,7 +7,7 @@ PV = "3.0.0"
 SRCREV = "c374840910c823f7669cf2e1229c7df7192ae880"
 
 SRC_URI = " \
-    git://github.com/openstack/puppet-vswitch.git;branch=master \
+    git://github.com/openstack/puppet-vswitch.git;branch=master;protocol=https \
     file://Add-gemspec.patch \
 "
 

--- a/recipes-support/puppetlabs-stdlib/puppetlabs-stdlib_git.bb
+++ b/recipes-support/puppetlabs-stdlib/puppetlabs-stdlib_git.bb
@@ -7,7 +7,7 @@ PV = "4.10.0"
 SRCREV = "0b4822be3d2242e83c28ab7fed6c5817adc322d5"
 
 SRC_URI = " \
-    git://github.com/puppetlabs/puppetlabs-stdlib.git;branch=master \
+    git://github.com/puppetlabs/puppetlabs-stdlib.git;branch=master;protocol=https \
     file://Add-gemspec.patch \
 "
 

--- a/recipes-support/ruby-shadow/ruby-shadow_git.bb
+++ b/recipes-support/ruby-shadow/ruby-shadow_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=137882914e5269b7268f0fe8e28a3f89"
 
 PV = "2.5.0"
 
-SRC_URI = "git://github.com/apalmblad/ruby-shadow.git"
+SRC_URI = "git://github.com/apalmblad/ruby-shadow.git;protocol=https"
 SRCREV = "d2e822d8a8bda61f0774debbfce363a7347ed893"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos