### PR TITLE
[sumo] python-pika: Update recipe to use new upstream main.

### DIFF
--- a/meta-openstack/recipes-devtools/python/python-pika.inc
+++ b/meta-openstack/recipes-devtools/python/python-pika.inc
@@ -8,6 +8,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=fb26c37045f9e0d2c5e24b711bd7f01c"
 PV = "0.10.0+git${SRCPV}"
 SRCREV = "b907f91415169b7f590174ab5d228e75a1b273e6"
 
-SRC_URI = "git://github.com/pika/pika;protocol=https"
+SRC_URI = "git://github.com/pika/pika;protocol=https;branch=main"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Upstream has changed the branch from master to main. That change makes the recipe unbuildable as-is. This commit updates the recipe to explicitly use the main branch moving forward.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

## Note to Reviewers:
In upstream versions later than `sumo`, this recipe is actually in `meta-openembedded` as part of `meta-python`.

## Testing:
Built locally and confirmed the build worked again.