### PR TITLE
Replace distutils dependency

### DIFF
--- a/meta-openstack/recipes-devtools/python/python-psycopg2_2.7.5.bb
+++ b/meta-openstack/recipes-devtools/python/python-psycopg2_2.7.5.bb
@@ -12,7 +12,7 @@ SRC_URI += " \
 SRC_URI[md5sum] = "9e7d6f695fc7f8d1c42a7905449246c9"
 SRC_URI[sha256sum] = "eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e"
 
-inherit distutils3 pypi
+inherit setuptools3 pypi
 
 DEPENDS += " \
     postgresql \

--- a/meta-openstack/recipes-extended/qpid/qpid-python_0.20.bb
+++ b/meta-openstack/recipes-extended/qpid/qpid-python_0.20.bb
@@ -12,4 +12,5 @@ SRC_URI[sha256sum] = "3ca55a5aa11fbbd4e26cb4cdafc9658489c159acadceac60c89d4bfb5c
 
 S = "${WORKDIR}/qpid-${PV}/python"
 
-inherit distutils3
+inherit setuptools3
+


### PR DESCRIPTION
## Reason

- distutils is deprecated and now showing a warning for this, it's a simple fix: you can just replace it with setuptools (legacy) instead

## Implementation:

- replace distutils inherit with setuptools legacy in qpid
- replace distutils inherit with setuptools legacy in qpid

Note:

- Doesn't depend on other packages using setuptools too or anything. It's just this change
- The removal of distutils from meta-openembedded is not necessary
- setuptools3, setuptools3-base, and setuptools3_legacy are all already a part of openembedded-core'
- With this change, we should be able to delete distutils from meta-openembedded

## Testing:

With the changes, bitbake packagefeed-ni-core does not produce any new errors
