### PR TITLE
Cherrypick "ruby: package plugins in main package" from upstream master

### DIFF
--- a/classes/ruby.bbclass
+++ b/classes/ruby.bbclass
@@ -158,6 +158,7 @@ FILES:${PN} += " \
         ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/specifications \
         ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/build_info \
         ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/extensions \
+        ${libdir}/ruby/gems/${RUBY_GEM_VERSION}/plugins \
         "
 
 FILES:${PN}-doc += " \


### PR DESCRIPTION
(cherry picked from commit d3acbcf51a36518ca6daa1376da5e54623285e7a)

This fixes [AB#2738357](https://dev.azure.com/ni/DevCentral/_workitems/edit/2738357) by including the ruby gem plugin directory in the main package. This fix did expose an existing error in yard-native which is captured by this story [AB#3073936](https://dev.azure.com/ni/DevCentral/_workitems/edit/3073936)

### Testing
Built the ni-extra feed with no QA issue errors and built some of the ruby gem recipes manually to make sure.